### PR TITLE
Modernize codebase for PHP 7/8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.3",
-        "smarty/smarty": "~3.1",
-		"nesbot/carbon": "~1.19"
+                "php": "^7.4 || ^8.0",
+                "smarty/smarty": "~3.1",
+                "nesbot/carbon": "^2.0"
 	},
 	"autoload": {
 		"psr-4": { 
@@ -28,5 +28,13 @@
 			"Mock\\": "src/Mock",
 			"Swiftlet\\": "src/Swiftlet"
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"kylekatarnls/update-helper": true
+		}
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9"
 	}
 }

--- a/composer.json.full
+++ b/composer.json.full
@@ -17,12 +17,12 @@
 			"url": "https://github.com/AliasIO/Swiftlet"
 		}
 	],
-	"require": {
-		"php": ">=5.3.3",
-        "smarty/smarty": "~3.1",
-        "phpunit/phpunit": "4.6.6",
-		"nesbot/carbon": "~1.19"
-	},
+        "require": {
+                "php": "^7.4 || ^8.0",
+                "smarty/smarty": "~3.1",
+                "phpunit/phpunit": "^9",
+                "nesbot/carbon": "^2.0"
+        },
 	"autoload": {
 		"psr-4": { 
 			"App\\": "src/App",

--- a/src/App/tests/SmsTest.php
+++ b/src/App/tests/SmsTest.php
@@ -9,12 +9,13 @@
 namespace App\tests;
 use App\Libraries\Sms;
 use App\Models\SimpleMessaging;
+use PHPUnit\Framework\TestCase;
 
 require_once 'vendor/autoload.php';
 
 
 
-class SmsTest extends \PHPUnit_Framework_TestCase {
+class SmsTest extends TestCase {
     /**
      * @var Sms
      */
@@ -26,7 +27,7 @@ class SmsTest extends \PHPUnit_Framework_TestCase {
     protected $outboxDir;
     protected $templateDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->workingDir = getcwd().DIRECTORY_SEPARATOR."src".DIRECTORY_SEPARATOR."App".DIRECTORY_SEPARATOR."tests";
         $this->sentDir = $this->workingDir.DIRECTORY_SEPARATOR."sentDir";
@@ -40,7 +41,7 @@ class SmsTest extends \PHPUnit_Framework_TestCase {
             $this->templateDir);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         //clear outgoing directory
         array_map('unlink', glob($this->outboxDir.DIRECTORY_SEPARATOR."*"));
@@ -93,7 +94,7 @@ class SmsTest extends \PHPUnit_Framework_TestCase {
             ->setText('Hello there');
         $smsBody = $this->sms->compose($simpleMessaging);
         //check for string pattern that smsBody must have
-        $this->assertRegExp('/^To:\s\+\d+?\n\n[\s\S]{0,160}/', $smsBody);
+        $this->assertMatchesRegularExpression('/^To:\s\+\d+?\n\n[\s\S]{0,160}/', $smsBody);
     }
 
     public function testDeleteSentMessage()

--- a/src/App/tests/UssdQueryTest.php
+++ b/src/App/tests/UssdQueryTest.php
@@ -10,8 +10,9 @@ namespace App\tests;
 
 
 use App\Libraries\UssdQuery;
+use PHPUnit\Framework\TestCase;
 
-class UssdQueryTest extends \PHPUnit_Framework_TestCase {
+class UssdQueryTest extends TestCase {
 
     private $param;
 
@@ -20,7 +21,7 @@ class UssdQueryTest extends \PHPUnit_Framework_TestCase {
      */
     private $ussdQuery;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->ussdQuery = new UssdQuery();
     }
@@ -44,7 +45,7 @@ class UssdQueryTest extends \PHPUnit_Framework_TestCase {
         $command = '*124#';
         $this->sendCommand($command);
         $pattern = str_replace('*','\\*',$command);
-        $this->assertRegExp('/\"AT\+CUSD=1, '.$pattern.' ,15\"/',
+        $this->assertMatchesRegularExpression('/\"AT\+CUSD=1, '.$pattern.' ,15\"/',
             $this->param,
             'Check if the send command exist in shell execute');
     }
@@ -58,14 +59,11 @@ class UssdQueryTest extends \PHPUnit_Framework_TestCase {
     }
 
 
-    /**
-     * @expectedException \Exception
-     */
     public function testGetRawUssdUCS2Exception()
     {
+        $this->expectException(\Exception::class);
         $array = $this->ussdQuery->getRawUssdUCS2();
     }
-
 
     public function testGetTextResult()
     {
@@ -82,13 +80,13 @@ class UssdQueryTest extends \PHPUnit_Framework_TestCase {
         $obj = json_decode($jsonMessage);
         //var_dump($obj);
 
-        $this->assertObjectHasAttribute('payload',$obj,'');
-        $this->assertObjectHasAttribute('message',$obj->payload,'');
-        $this->assertObjectHasAttribute('needReply',$obj->payload,'');
-        $this->assertObjectHasAttribute('error',$obj,'');
-        $this->assertObjectHasAttribute('success',$obj,'');
+        $this->assertObjectHasProperty('payload',$obj,'');
+        $this->assertObjectHasProperty('message',$obj->payload,'');
+        $this->assertObjectHasProperty('needReply',$obj->payload,'');
+        $this->assertObjectHasProperty('error',$obj,'');
+        $this->assertObjectHasProperty('success',$obj,'');
 
-        $this->assertAttributeNotEmpty('message',$obj->payload,'');
+        $this->assertNotEmpty($obj->payload->message);
         $this->assertTrue($obj->success,'Success attribute value should be true');
     }
 
@@ -98,10 +96,10 @@ class UssdQueryTest extends \PHPUnit_Framework_TestCase {
         $obj = json_decode($jsonMessage);
         //var_dump($obj);
 
-        $this->assertObjectHasAttribute('payload',$obj,'');
-        $this->assertObjectHasAttribute('exception',$obj->error,'');
-        $this->assertObjectHasAttribute('error',$obj,'');
-        $this->assertObjectHasAttribute('success',$obj,'');
+        $this->assertObjectHasProperty('payload',$obj,'');
+        $this->assertObjectHasProperty('exception',$obj->error,'');
+        $this->assertObjectHasProperty('error',$obj,'');
+        $this->assertObjectHasProperty('success',$obj,'');
 
         $this->assertFalse($obj->success,'Success attribute value should be false');
     }

--- a/src/Swiftlet/Abstracts/Controller.php
+++ b/src/Swiftlet/Abstracts/Controller.php
@@ -39,7 +39,7 @@ abstract class Controller extends Common implements ControllerInterface
     /**
      * @param \Swiftlet\Interfaces\App $app
      */
-    public function __construct(AppInterface $app = null)
+    public function __construct(?AppInterface $app = null)
     {
         $this->app = $app;
     }

--- a/src/Swiftlet/tests/AppTest.php
+++ b/src/Swiftlet/tests/AppTest.php
@@ -5,20 +5,21 @@ namespace Mock;
 require_once 'vendor/autoload.php';
 
 use \Mock\Controllers\Index as IndexController;
+use PHPUnit\Framework\TestCase;
 
-class AppTest extends \PHPUnit_Framework_TestCase
+class AppTest extends TestCase
 {
 	protected $app;
 
 	protected $view;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->view = new View;
 
 		$this->app = new App($this->view, 'Mock');
 
-		set_error_handler(array($this->app, 'error'), E_ALL | E_STRICT);
+		set_error_handler(array($this->app, 'error'), E_ALL);
 
 		date_default_timezone_set('UTC');
 	}
@@ -52,11 +53,9 @@ class AppTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($this->app->registerHook('test', new IndexController, new View), $this->app);
 	}
 
-	/**
-	 * @expectedException \ErrorException
-	 */
-	function testError()
-	{
-		$this->app->error(null, null, null, null);
-	}
+        function testError()
+        {
+                $this->expectException(\ErrorException::class);
+                $this->app->error(null, null, null, null);
+        }
 }

--- a/src/Swiftlet/tests/ControllerTest.php
+++ b/src/Swiftlet/tests/ControllerTest.php
@@ -5,14 +5,15 @@ namespace Mock;
 require_once 'vendor/autoload.php';
 
 use \Mock\Controllers\Index as IndexController;
+use PHPUnit\Framework\TestCase;
 
-class ControllerTest extends \PHPUnit_Framework_TestCase
+class ControllerTest extends TestCase
 {
 	protected $controller;
 
 	protected $view;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->view       = new View;
 		$this->controller = new IndexController;

--- a/src/Swiftlet/tests/LibraryTest.php
+++ b/src/Swiftlet/tests/LibraryTest.php
@@ -5,12 +5,13 @@ namespace Mock;
 require_once 'vendor/autoload.php';
 
 use \Mock\Libraries\Mock as MockLibrary;
+use PHPUnit\Framework\TestCase;
 
-class LibraryTest extends \PHPUnit_Framework_TestCase
+class LibraryTest extends TestCase
 {
 	protected $library;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->library = new MockLibrary;
 	}

--- a/src/Swiftlet/tests/PluginTest.php
+++ b/src/Swiftlet/tests/PluginTest.php
@@ -3,12 +3,13 @@
 namespace Mock;
 
 require_once 'vendor/autoload.php';
+use PHPUnit\Framework\TestCase;
 
-class PluginTest extends \PHPUnit_Framework_TestCase
+class PluginTest extends TestCase
 {
 	protected $plugin;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->plugin = new Plugins\Mock;
 	}

--- a/src/Swiftlet/tests/ViewTest.php
+++ b/src/Swiftlet/tests/ViewTest.php
@@ -3,12 +3,13 @@
 namespace Swiftlet;
 
 require_once 'vendor/autoload.php';
+use PHPUnit\Framework\TestCase;
 
-class ViewTest extends \PHPUnit_Framework_TestCase
+class ViewTest extends TestCase
 {
 	protected $view;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->view = new View();
 	}


### PR DESCRIPTION
## Summary
- require PHP 7.4+ and Carbon 2, add PHPUnit 9 for development
- update framework controller for explicit nullable app dependency
- revise tests for PHPUnit 9 syntax

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_68aeb235f2f0832ab3d58cf541f720a1